### PR TITLE
docker-compose.yamlを作成

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM ruby:3.2.2
+FROM ruby:3.3

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,9 @@
+services:
+  app:
+    build: . # Dockerfileがあるディレクトリへの相対パス
+    ports:
+      - 3000:3000
+    volumes:
+      - .:/app # [ホストディレクトリ]:[コンテナ内ディレクトリ]
+    working_dir: /app
+    tty: true # コンテナの正常終了を阻止


### PR DESCRIPTION
バックグラウンドでコンテナ起動（ `docker compose up -d --build` ）とか、 `run` やと普通に動くんやけど（↓画像）
![Screenshot 2024-01-19 10 19 21](https://github.com/ok-os-job-change-team/tetsuya-backend-bootcamp/assets/95535099/28e88954-1e3e-4b4f-b15e-dd3fde03f967)

`docker compose up --build` だと `Attaching to app-1` で止まるんよね（↓画像・最後はctrl + c で終了してる）
ディレクトリにでかいデータとかはないんやけど
![Screenshot 2024-01-19 10 27 17](https://github.com/ok-os-job-change-team/tetsuya-backend-bootcamp/assets/95535099/17a20f3e-4260-4738-b3ff-4a5e77a58844)
