### PR TITLE
feat:Userクラスに、usersテーブルのレコードを取得するself.allメソッドを追加した

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,0 @@
-# 環境変数
-ROOT_PASS=root
-DB_NAME=db
-DB_USER=user
-DB_PASS=password
-DB_PORT=3306
-TZ=Asia/Tokyo

--- a/.env
+++ b/.env
@@ -1,0 +1,7 @@
+# 環境変数
+ROOT_PASS=root
+DB_NAME=db
+DB_USER=user
+DB_PASS=password
+DB_PORT=3306
+TZ=Asia/Tokyo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,11 @@
-FROM ruby:3.3
+# apt-get出来る様にdebian版を使う。
+FROM mysql:8.0.36-debian
+# コンテナ内で日本語が打てるようにlocalesを変更と、いらないファイル削除する
+RUN apt-get update \
+  && apt-get install -y locales \
+  && sed -i -E 's/# (ja_JP.UTF-8)/\1/' /etc/locale.gen \
+  && locale-gen \
+  && update-locale LANG=ja_JP.UTF-8 \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+ENV LC_ALL ja_JP.UTF-8

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem "rspec"
+gem "mysql2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.5.0)
+    mysql2 (0.5.6)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -21,6 +22,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  mysql2
   rspec
 
 BUNDLED WITH

--- a/app/models/test/user_all_test.rb
+++ b/app/models/test/user_all_test.rb
@@ -1,0 +1,4 @@
+require_relative '../user'
+
+# usersテーブルのレコードを全て標準出力する
+puts User.all

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,5 @@
+require 'mysql2'
+
 class User
   attr_reader :id, :email, :password, :created_at,  :updated_at
 
@@ -11,5 +13,19 @@ class User
 
   def present?
     @id != nil
+  end
+
+  def self.all
+    # usersテーブルのレコードを全て取得する
+
+    client = Mysql2::Client.new(
+      host: 'db', # Docker composeのサービス名をホストとして指定する
+      username: 'root',
+      password: 'root',
+      database: 'test'
+    )
+
+    client.query('SELECT * FROM users').each do |e1|
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,7 +25,6 @@ class User
       database: 'test'
     )
 
-    client.query('SELECT * FROM users').each do |e1|
-    end
+    client.query('SELECT * FROM users').map { _1 }
   end
 end

--- a/conf/my.conf
+++ b/conf/my.conf
@@ -1,0 +1,6 @@
+[mysqld]
+character-set-server=utf8mb4
+collation-server=utf8mb4_bin
+
+[client]
+default-character-set=utf8mb4

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,9 +1,36 @@
 services:
   app:
-    build: . # Dockerfileがあるディレクトリへの相対パス
+    image: ruby:3.3
     ports:
       - 3000:3000
     volumes:
       - .:/app # [ホストディレクトリ]:[コンテナ内ディレクトリ]
     working_dir: /app
     tty: true # コンテナの正常終了を阻止
+
+  db:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    platform: linux/amd64
+    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    environment:
+      MYSQL_ROOT_PASSWORD: ${ROOT_PASS}
+      # MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_USER: ${DB_USER}
+      MYSQL_PASSWORD: ${DB_PASS}
+      TZ: ${TZ}
+    env_file:
+      - .env
+    ports:
+      - ${DB_PORT}:3306
+    volumes:
+      - data-volume:/var/lib/mysql
+      - ./conf/my.conf:/etc/mysql/conf.d/my.cnf
+      - ./mysql:/sql
+    tty: true
+    stdin_open: true
+
+volumes:
+  data-volume:


### PR DESCRIPTION
## 今回対応した issue

<!-- #の後に続けてissue番号を追記すること。 -->

- closes #21 

## やったこと

<!-- このプルリクで何をしたのか？ -->

- Userクラスから、MySQLにアクセスできるようにした
- Userクラスに、usersテーブルのレコードを取得する`self.all`メソッドを追加した

## 残りの作業

<!-- issueの残りの完了条件（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。） -->

- なし

## できるようになること（ユーザ目線）

<!-- 何ができるようになるのか？（あれば。無いなら「無し」で OK） -->

- なし

## できなくなること（ユーザ目線）

<!-- 何ができなくなるのか？（あれば。無いなら「無し」で OK） -->

- なし

## その他

<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->

- MySQLにログインできない症状が発生し、Dockerのデータボリュームを含む全てを初期化し、再構築することで解決した

## 動作確認

<!-- どのような動作確認を行ったのか？　結果はどうか？ -->

- `test/user_all_test.rb`を実行した
![Screenshot 2024-03-22 14 56 35](https://github.com/ok-os-job-change-team/tetsuya-backend-bootcamp/assets/95535099/3b5aadfd-ed25-493b-9707-c0c7ce86ae5b)

